### PR TITLE
Initialize Telegram bot project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Telegram AI Bot
+
+This repository contains a minimal project structure for a Telegram bot that
+uses an AI service (such as OpenAI) to respond to user messages.
+
+## Project Layout
+
+```
+project/
+├── bot.py            # Entry point that configures polling or webhook
+├── handlers.py       # Handlers for button presses and routing
+├── ai_client.py      # Wrapper over the AI API
+├── prompts.yaml      # Mapping from button labels to prompts
+├── config.yaml       # Bot settings (token stored in bot.py)
+└── requirements.txt  # Dependencies list
+```
+
+## Getting Started
+
+1. Create a virtual environment and install dependencies:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   pip install -r project/requirements.txt
+   ```
+2. Set up your bot token inside `project/bot.py`.
+3. Implement the missing logic in the module files.
+4. Run the bot:
+   ```bash
+   python project/bot.py
+   ```
+
+## GitHub Tips
+
+- Create issues to track features or bugs.
+- Use Pull Requests for code review. Include clear descriptions and link to
+  related issues.
+- Configure branch protections if this is a collaborative project.
+

--- a/project/ai_client.py
+++ b/project/ai_client.py
@@ -1,0 +1,11 @@
+"""Wrapper around an AI API such as OpenAI."""
+
+# TODO: Implement the client that communicates with the AI service.
+
+class AIClient:
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+
+    def generate_response(self, prompt: str) -> str:
+        """Send the prompt to the AI service and return its response."""
+        pass

--- a/project/bot.py
+++ b/project/bot.py
@@ -1,0 +1,11 @@
+"""Main bot entry point. Configures polling or webhook.
+Token is defined here, not in config.yaml as the user requested.
+"""
+
+# TODO: Implement the Telegram bot initialization and main loop here.
+
+def main():
+    pass
+
+if __name__ == "__main__":
+    main()

--- a/project/config.yaml
+++ b/project/config.yaml
@@ -1,0 +1,6 @@
+# Bot configuration settings
+# The API token is defined in bot.py as per project description.
+
+# Example settings
+use_webhook: false
+webhook_url: ""

--- a/project/handlers.py
+++ b/project/handlers.py
@@ -1,0 +1,9 @@
+"""Message and command handlers for the Telegram bot.
+Defines routing logic for incoming updates.
+"""
+
+# TODO: Implement handlers and dispatching logic here.
+
+
+def register_handlers(dispatcher):
+    pass

--- a/project/prompts.yaml
+++ b/project/prompts.yaml
@@ -1,0 +1,3 @@
+# Mapping from button labels to AI prompts
+# Example:
+# start: "Hello, how can I help you?"

--- a/project/requirements.txt
+++ b/project/requirements.txt
@@ -1,0 +1,4 @@
+# Project dependencies
+# Example:
+# aiogram==3.*
+# openai==1.*


### PR DESCRIPTION
## Summary
- scaffold an initial project layout under `project/`
- add placeholders for bot, handlers and AI client
- include example `prompts.yaml`, `config.yaml` and `requirements.txt`
- document setup and GitHub workflow in `README.md`

## Testing
- `python -m py_compile project/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684aaa8d2ca88332b89ef43e8b0912d6