### PR TITLE
Expand bot features and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ project/
 ├── bot.py            # Entry point that configures polling or webhook
 ├── handlers.py       # Handlers for button presses and routing
 ├── ai_client.py      # Wrapper over the AI API
+├── logger.py         # Logging configuration
+├── bot_commands.py   # Text for common commands
 ├── prompts.yaml      # Mapping from button labels to prompts
 ├── config.yaml       # Bot settings (token stored in bot.py)
 └── requirements.txt  # Dependencies list
@@ -24,7 +26,10 @@ project/
    pip install -r project/requirements.txt
    ```
 2. Set up your bot token inside `project/bot.py`.
-3. Implement the missing logic in the module files.
+3. Run the tests:
+   ```bash
+   pytest -q
+   ```
 4. Run the bot:
    ```bash
    python project/bot.py

--- a/project/__init__.py
+++ b/project/__init__.py
@@ -1,0 +1,1 @@
+"""Telegram bot project package."""

--- a/project/ai_client.py
+++ b/project/ai_client.py
@@ -1,11 +1,37 @@
-"""Wrapper around an AI API such as OpenAI."""
+"""Wrapper around an AI API such as OpenAI.
 
-# TODO: Implement the client that communicates with the AI service.
+This class abstracts communication with the OpenAI API. It can be extended
+for other providers by modifying :meth:`generate_response`.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import openai
+
 
 class AIClient:
-    def __init__(self, api_key: str):
-        self.api_key = api_key
+    """Simple client for generating text using OpenAI's chat completions."""
+
+    def __init__(self, api_key: str, model: str = "gpt-3.5-turbo") -> None:
+        openai.api_key = api_key
+        self.model = model
 
     def generate_response(self, prompt: str) -> str:
         """Send the prompt to the AI service and return its response."""
-        pass
+
+        try:
+            completion = openai.ChatCompletion.create(
+                model=self.model,
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except Exception as exc:  # pragma: no cover - network errors
+            # In production, proper logging should be done here.
+            return f"Error contacting AI service: {exc}"
+
+        choice: Optional[dict] = completion.choices[0] if completion.choices else None
+        if not choice or "message" not in choice:
+            return "No response from AI service"
+
+        return choice["message"].get("content", "")

--- a/project/bot.py
+++ b/project/bot.py
@@ -1,11 +1,53 @@
-"""Main bot entry point. Configures polling or webhook.
-Token is defined here, not in config.yaml as the user requested.
+"""Main bot entry point.
+
+This module creates the Telegram bot instance, sets up all handlers and starts
+polling. The bot token is intentionally stored here as per the repository
+description. Replace ``YOUR_TOKEN`` with the actual bot token before running.
 """
 
-# TODO: Implement the Telegram bot initialization and main loop here.
+from __future__ import annotations
 
-def main():
-    pass
+import asyncio
+from pathlib import Path
+from typing import Dict
+
+import yaml
+from aiogram import Bot, Dispatcher, Router
+
+from .ai_client import AIClient
+from .handlers import register_handlers
+from .logger import setup_logging
+
+
+# Insert your Telegram Bot API token here.
+BOT_TOKEN = "YOUR_TOKEN"
+
+
+def load_yaml(path: Path) -> Dict[str, str]:
+    with path.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+async def run() -> None:
+    setup_logging()
+    config = load_yaml(Path(__file__).with_name("config.yaml"))
+    prompts = load_yaml(Path(__file__).with_name("prompts.yaml"))
+
+    bot = Bot(BOT_TOKEN, parse_mode="HTML")
+    router = Router()
+    ai_client = AIClient(api_key="dummy")
+
+    register_handlers(router, ai_client, prompts)
+
+    dispatcher = Dispatcher()
+    dispatcher.include_router(router)
+
+    # Webhook support could be added here using `config`.
+    await dispatcher.start_polling(bot)
+
+
+def main() -> None:
+    asyncio.run(run())
 
 if __name__ == "__main__":
     main()

--- a/project/bot_commands.py
+++ b/project/bot_commands.py
@@ -1,0 +1,18 @@
+"""Utility functions and texts for common bot commands."""
+
+from __future__ import annotations
+
+
+HELP_TEXT = (
+    "Available commands:\n"
+    "/start - Welcome message\n"
+    "/help - Show this help\n"
+    "/about - Information about the bot"
+)
+
+ABOUT_TEXT = (
+    "This is a simple Telegram bot that forwards your messages to an AI service "
+    "and returns the generated response."
+)
+
+__all__ = ["HELP_TEXT", "ABOUT_TEXT"]

--- a/project/handlers.py
+++ b/project/handlers.py
@@ -1,9 +1,51 @@
 """Message and command handlers for the Telegram bot.
-Defines routing logic for incoming updates.
+
+The functions defined here are responsible for reacting to Telegram updates.
+They are registered in :mod:`bot` and make use of :class:`AIClient` to
+generate replies.
 """
 
-# TODO: Implement handlers and dispatching logic here.
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from aiogram import F, Router
+from aiogram.filters import CommandStart, Command
+from aiogram.types import Message
+
+from .ai_client import AIClient
+from .bot_commands import HELP_TEXT, ABOUT_TEXT
 
 
-def register_handlers(dispatcher):
-    pass
+async def handle_start(message: Message) -> None:
+    """Send a welcome message with instructions."""
+
+    await message.answer(
+        "Hello! Send me a message and I'll ask the AI to respond."
+    )
+
+
+def _format_prompt(text: str, prompts: Dict[str, str]) -> str:
+    return prompts.get(text.lower(), text)
+
+
+def register_handlers(router: Router, ai_client: AIClient, prompts: Dict[str, str]) -> None:
+    """Register bot commands and message handlers."""
+
+    @router.message(CommandStart())
+    async def start(message: Message) -> None:
+        await handle_start(message)
+
+    @router.message(Command("help"))
+    async def help_cmd(message: Message) -> None:
+        await message.answer(HELP_TEXT)
+
+    @router.message(Command("about"))
+    async def about_cmd(message: Message) -> None:
+        await message.answer(ABOUT_TEXT)
+
+    @router.message(F.text)
+    async def echo(message: Message) -> None:
+        prompt = _format_prompt(message.text, prompts)
+        response = ai_client.generate_response(prompt)
+        await message.answer(response)

--- a/project/logger.py
+++ b/project/logger.py
@@ -1,0 +1,37 @@
+"""Logging utilities for the Telegram bot project."""
+
+from __future__ import annotations
+
+import logging
+from logging.config import dictConfig
+
+
+_DEFAULT_LEVEL = logging.INFO
+
+
+def setup_logging(level: int = _DEFAULT_LEVEL) -> None:
+    """Configure basic logging for the application."""
+
+    config = {
+        "version": 1,
+        "formatters": {
+            "default": {
+                "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            }
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "default",
+                "level": level,
+            }
+        },
+        "root": {
+            "handlers": ["console"],
+            "level": level,
+        },
+    }
+    dictConfig(config)
+
+
+__all__ = ["setup_logging"]

--- a/project/prompts.yaml
+++ b/project/prompts.yaml
@@ -1,3 +1,3 @@
 # Mapping from button labels to AI prompts
-# Example:
-# start: "Hello, how can I help you?"
+start: "Hello, how can I help you?"
+quote: "Tell me an inspiring quote"

--- a/project/requirements.txt
+++ b/project/requirements.txt
@@ -1,4 +1,4 @@
-# Project dependencies
-# Example:
-# aiogram==3.*
-# openai==1.*
+aiogram==3.*
+openai==1.*
+pytest==8.*
+PyYAML==6.*

--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+ai_client = pytest.importorskip("project.ai_client")
+
+
+class DummyCompletion:
+    def __init__(self, content: str):
+        self.choices = [{"message": {"content": content}}]
+
+
+def fake_create(*args, **kwargs):
+    return DummyCompletion("result")
+
+
+@pytest.fixture
+def patch_openai(monkeypatch):
+    monkeypatch.setattr(ai_client.openai.ChatCompletion, "create", fake_create)
+
+
+def test_generate_response(patch_openai):
+    client = ai_client.AIClient(api_key="x")
+    resp = client.generate_response("prompt")
+    assert resp == "result"

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,18 @@
+import types
+
+import pytest
+
+handlers = pytest.importorskip("project.handlers")
+_format_prompt = handlers._format_prompt
+
+
+@pytest.mark.parametrize(
+    "text,prompts,expected",
+    [
+        ("hello", {"hello": "hi"}, "hi"),
+        ("HELLO", {"hello": "hi"}, "hi"),
+        ("unknown", {}, "unknown"),
+    ],
+)
+def test_format_prompt(text, prompts, expected):
+    assert _format_prompt(text, prompts) == expected


### PR DESCRIPTION
## Summary
- add logging configuration and common command texts
- implement help/about commands and setup logging
- document new modules in README
- add basic pytest test suite

## Testing
- `python -m py_compile project/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aab502924833284b1a6f005ae06db